### PR TITLE
fixes #63: AIOCallback is now decorated with UnmanagedFunctionPointer…

### DIFF
--- a/nng.NETCore/Native/Aio.cs
+++ b/nng.NETCore/Native/Aio.cs
@@ -11,6 +11,7 @@ namespace nng.Native.Aio
 #endif
     public sealed class UnsafeNativeMethods
     {
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void AioCallback(IntPtr arg);
         //public delegate void AioCancelFunction(nng_aio aio, IntPtr ptr, Int32 val);
 


### PR DESCRIPTION
AIOCallback deelegate is now decorated with `UnmanagedFunctionPointer(CallingConvention.Cdecl)` attribute so as not to cause ESP-register error in native dll. Modification does not seem to impact x64 targets.