### PR TITLE
Prepare release 1.1.1.1

### DIFF
--- a/common.targets
+++ b/common.targets
@@ -23,10 +23,10 @@
     <Authors>Subor</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Owners>Subor</Owners>
-    <PackageProjectUrl>https://github.com/subor/nng.NETCore</PackageProjectUrl>
+    <PackageProjectUrl>https://github.com/jeikabu/nng.NETCore</PackageProjectUrl>
     <Summary>.NET Core bindings to nng</Summary>
-    <PackageTags>subor nng csnng</PackageTags>
+    <PackageTags>nng csnng</PackageTags>
     <Description>.NET Core bindings to nng (https://github.com/nanomsg/nng)</Description>
-    <RepositoryUrl>https://github.com/subor/nng.NETCore</RepositoryUrl>
+    <RepositoryUrl>https://github.com/jeikabu/nng.NETCore</RepositoryUrl>
   </PropertyGroup>
 </Project>

--- a/nng.NETCore/Native/Aio.cs
+++ b/nng.NETCore/Native/Aio.cs
@@ -11,8 +11,10 @@ namespace nng.Native.Aio
 #endif
     public sealed class UnsafeNativeMethods
     {
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void AioCallback(IntPtr arg);
+
+        //[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         //public delegate void AioCancelFunction(nng_aio aio, IntPtr ptr, Int32 val);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]

--- a/nng.NETCore/nng.NETCore.csproj
+++ b/nng.NETCore/nng.NETCore.csproj
@@ -10,8 +10,13 @@
     <!-- Including assembly as part of runtimes/ so don't want it placed in lib/ -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <PackageId>Subor.nng.NETCore</PackageId>
-    <PackageVersion>1.1.1.0</PackageVersion>
-    <Version>1.1.1.0</Version>
+    <PackageVersion>1.1.1.1</PackageVersion>
+    <Version>1.1.1.1</Version>
+    <!-- Needed to avoid `error NU5128` when running `dotnet pack`.
+    Assemblies for targetted frameworks are in runtimes/ instead of lib/ or ref/ 
+    See: https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128#scenario-2
+    -->
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/nng.Shared/nng.Shared.csproj
+++ b/nng.Shared/nng.Shared.csproj
@@ -4,13 +4,14 @@
 
   <PropertyGroup>
     <OutputPath>..\packer\bin\$(Configuration)\lib\</OutputPath>
+    <!-- To enable code coverage -->
     <DebugType>full</DebugType>
   </PropertyGroup>
 
   <PropertyGroup>
     <PackageId>Subor.nng.NETCore.Shared</PackageId>
-    <PackageVersion>1.1.1.0</PackageVersion>
-    <Version>1.1.1.0</Version>
+    <PackageVersion>1.1.1.1</PackageVersion>
+    <Version>1.1.1.1</Version>
 
     <PackageOutputPath>../bin/$(Configuration)</PackageOutputPath>
   </PropertyGroup>


### PR DESCRIPTION
- Using `dotnet pack` with dotnet core resulted in error NU5128 because
Subor.nng.NETCore package has empty ref/ and lib/