### PR TITLE
fixes #66 Spurious EADDRINUSE test failures

### DIFF
--- a/tests/AioTests.cs
+++ b/tests/AioTests.cs
@@ -47,7 +47,7 @@ namespace nng.Tests
             pull.Cancel();
             // Cancel happens asynchronously.  Give callback a chance to happen
             await WaitReady();
-            Assert.Equal((await pullTask).Err(), NngErrno.ECANCELED);
+            Assert.Equal(NngErrno.ECANCELED, (await pullTask).Err());
         }
 
         // [Fact]
@@ -74,7 +74,7 @@ namespace nng.Tests
 
             // Immediate timeout
             pull.SetTimeout(NNG_DURATION_ZERO);
-            Assert.Equal((await pull.Receive(CancellationToken.None)).Err(), NngErrno.ETIMEDOUT);
+            Assert.Equal(NngErrno.ETIMEDOUT, (await pull.Receive(CancellationToken.None)).Err());
 
             // Infinite timeout
             pull.SetTimeout(NNG_DURATION_INFINITE);

--- a/tests/ListenerTests.cs
+++ b/tests/ListenerTests.cs
@@ -33,7 +33,7 @@ namespace nng.Tests
                 Assert.Equal(0, listener.Start());
                 await WaitReady();
                 var subSocket = Factory.SubscriberOpen().Unwrap();
-                Assert.NotNull(subSocket.DialerCreate(url));
+                Assert.NotNull(subSocket.DialerCreate(url).Unwrap());
             }
         }
 

--- a/tests/PubSubTests.cs
+++ b/tests/PubSubTests.cs
@@ -39,6 +39,34 @@ namespace nng.Tests
 
         [Theory]
         [ClassData(typeof(TransportsClassData))]
+        public async Task Basic(string url)
+        {
+            Fixture.TestIterate(() =>
+            {
+                using (var pub = Factory.PublisherOpen().Unwrap())
+                using (var sub = Factory.SubscriberOpen().Unwrap())
+                {
+                    var listener = pub.ListenWithListener(url).Unwrap();
+                    sub.Dial(GetDialUrl(listener, url)).Unwrap();
+                }
+
+                // Manually create listener/dialer
+                using (var pub = Factory.PublisherOpen().Unwrap())
+                using (var listener0 = pub.ListenerCreate(url).Unwrap())
+                {
+                    // Must start listener before using `NNG_OPT_LOCADDR`
+                    listener0.Start();
+                    using (var sub = Factory.SubscriberOpen().Unwrap())
+                    using (var dialer1 = sub.DialerCreate(GetDialUrl(listener0, url)).Unwrap())
+                    {
+
+                    }
+                }
+            });
+        }
+
+        [Theory]
+        [ClassData(typeof(TransportsClassData))]
         public async Task BasicPubSub(string url)
         {
             using (var pubSocket = Factory.PublisherOpen().ThenListenAs(out var listener, url).Unwrap())

--- a/tests/SurveyTests.cs
+++ b/tests/SurveyTests.cs
@@ -36,6 +36,8 @@ namespace nng.Tests
                 using (var bus0 = Factory.SurveyorOpen().Unwrap())
                 using (var listener0 = bus0.ListenerCreate(url).Unwrap())
                 {
+                    // Must start listener before using `NNG_OPT_LOCADDR`
+                    listener0.Start();
                     using (var bus1 = Factory.RespondentOpen().Unwrap())
                     using (var dialer1 = bus1.DialerCreate(GetDialUrl(listener0, url)).Unwrap())
                     {

--- a/tests/Util.cs
+++ b/tests/Util.cs
@@ -57,6 +57,12 @@ namespace nng.Tests
             return url;
         }
 
+        public static async Task Wait(IEnumerable<Task> tasks, int timeoutMs = DefaultTimeoutMs)
+        {
+            var timeout = Task.Delay(timeoutMs);
+            await Task.WhenAny(Task.WhenAll(tasks), timeout);
+        }
+
         public static Task AssertWait(params Task[] tasks)
         {
             return AssertWait(tasks, DefaultTimeoutMs);
@@ -65,7 +71,19 @@ namespace nng.Tests
         public static async Task AssertWait(IEnumerable<Task> tasks, int timeoutMs = DefaultTimeoutMs)
         {
             var timeout = Task.Delay(timeoutMs);
-            Assert.NotEqual(timeout, await Task.WhenAny(timeout, Task.WhenAll(tasks)));
+            var first = await Task.WhenAny(Task.WhenAll(tasks), timeout);
+            Assert.NotEqual(timeout, first);
+        }
+
+        public static Task CancelAfterWait(CancellationTokenSource cts, params Task[] tasks)
+        {
+            return CancelAfterWait(tasks, cts);
+        }
+
+        public static async Task CancelAfterWait(IEnumerable<Task> tasks, CancellationTokenSource cts, int cancelAfterMs = ShortTestMs, int timeoutMs = DefaultTimeoutMs)
+        {
+            cts.CancelAfter(cancelAfterMs);
+            await Wait(tasks, timeoutMs);
         }
 
         public static Task CancelAfterAssertwait(CancellationTokenSource cts, params Task[] tasks)


### PR DESCRIPTION
- Starting with nng 1.2 NNG_OPT_LOCADDR fails unless the listener is started