### PR TITLE
fix #48, fix #53 wrap stream and iov APIs

### DIFF
--- a/nng.NETCore/AsyncContext.cs
+++ b/nng.NETCore/AsyncContext.cs
@@ -2,6 +2,7 @@ using nng.Native;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -11,12 +12,107 @@ namespace nng
     using static nng.Native.Ctx.UnsafeNativeMethods;
     using static nng.Native.Msg.UnsafeNativeMethods;
 
+    /// <summary>
+    /// High-level wrapper around `nng_aio`.
+    /// </summary>
+    public class AsyncIO : INngAio
+    {
+        public static NngResult<INngAio> Create(AioCallback callback)
+        {
+            // Make a copy to ensure an automatically created delegate doesn't get GC'd while native code 
+            // is still using it:
+            // https://stackoverflow.com/questions/6193711/call-has-been-made-on-garbage-collected-delegate-in-c
+            // https://docs.microsoft.com/en-us/cpp/dotnet/how-to-marshal-callbacks-and-delegates-by-using-cpp-interop
+            var res = nng_aio_alloc(out var aioHandle, callback, IntPtr.Zero);
+            return NngResult<INngAio>.OkThen(res, () => new AsyncIO {aioHandle = aioHandle, gcHandle = GCHandle.Alloc(callback) });
+        }
+
+        public nng_aio NngAio => aioHandle;
+
+        public void SetMsg(nng_msg msg)
+        {
+            nng_aio_set_msg(aioHandle, msg);
+        }
+
+        public NngResult<Unit> SetIov(Span<nng_iov> iov)
+        {
+            if (iov.Length > Defines.MAX_IOV_BUFFERS)
+                return Unit.Err(Defines.NngErrno.EINVAL);
+            return Unit.OkIfZero(nng_aio_set_iov(aioHandle, iov.ToArray()));
+        }
+
+        public void SetTimeout(int msTimeout)
+        {
+            SetTimeout(new nng_duration { TimeMs = msTimeout });
+        }
+
+        public void SetTimeout(nng_duration timeout)
+        {
+            nng_aio_set_timeout(aioHandle, timeout);
+        }
+
+        public UIntPtr Count() => nng_aio_count(aioHandle);
+
+        public NngResult<Unit> GetResult()
+        {
+            return Unit.OkIfZero(nng_aio_result(aioHandle));
+        }
+
+        public nng_msg GetMsg()
+        {
+            return nng_aio_get_msg(aioHandle);
+        }
+
+        public IntPtr GetOutput(UInt32 index)
+        {
+            return nng_aio_get_output(aioHandle, index);
+        }
+
+        public void Wait()
+        {
+            nng_aio_wait(aioHandle);
+        }
+
+        public void Cancel()
+        {
+            nng_aio_cancel(aioHandle);
+        }
+
+        ~AsyncIO() => Dispose(false);
+
+        #region IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+                nng_aio_stop(aioHandle);
+            }
+            
+            nng_aio_free(aioHandle);
+            aioHandle = nng_aio.Null;
+            gcHandle.Free();
+            disposed = true;
+        }
+        bool disposed = false;
+        #endregion
+
+        protected nng_aio aioHandle = nng_aio.Null;
+        GCHandle gcHandle;
+    }
+
     public abstract class AsyncBase<T> : IAsyncContext
     {
         public IMessageFactory<T> Factory { get; protected set; }
         public ISocket Socket { get; protected set; }
 
-        protected nng_aio aioHandle = nng_aio.Null;
         protected enum AsyncState
         {
             Init,
@@ -26,23 +122,23 @@ namespace nng
         }
         protected AsyncState State { get; set; } = AsyncState.Init;
 
-        public void SetTimeout(int msTimeout)
-        {
-            nng_aio_set_timeout(aioHandle, new nng_duration { TimeMs = msTimeout });
-        }
-        public void Cancel()
-        {
-            nng_aio_cancel(aioHandle);
-        }
+        public void SetTimeout(int msTimeout) => Aio.SetTimeout(msTimeout);
+        public void Cancel() => Aio.Cancel();
 
-        protected int InitAio()
+        public INngAio Aio { get; protected set; }
+
+        protected NngResult<Unit> InitAio()
         {
-            // Make a copy to ensure an automatically created delegate doesn't get GC'd while native code 
-            // is still using it:
-            // https://stackoverflow.com/questions/6193711/call-has-been-made-on-garbage-collected-delegate-in-c
-            aioCallback = new AioCallback(callback);
-            var res = nng_aio_alloc(out aioHandle, aioCallback, IntPtr.Zero);
-            return res;
+            var res = AsyncIO.Create(callback);
+            if (res.IsOk())
+            {
+                Aio = res.Ok();
+                return Unit.Ok;
+            }
+            else
+            {
+                return Unit.Err(res.Err());
+            }
         }
 
         protected abstract void AioCallback(IntPtr argument);
@@ -71,45 +167,23 @@ namespace nng
 
         protected void HandleFailedSend()
         {
-            var unsentMsg = nng_aio_get_msg(aioHandle);
-            nng_msg_free(unsentMsg);
+            var _unsentMsg = Aio.GetMsg();
         }
 
         // Synchronization object used for aio callbacks
         protected object sync = new object();
-        AioCallback aioCallback;
-        // FIXME: TODO: callbacks still getting GC'd
-        static ConcurrentDictionary<AioCallback, bool> callbacks = new ConcurrentDictionary<AioCallback, bool>();
-
-        ~AsyncBase()
-        {
-            Dispose(false);
-        }
 
         #region IDisposable
         public void Dispose()
         {
-            Dispose(true);
-            GC.SuppressFinalize(this);
+            Aio?.Dispose();
         }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (disposed)
-                return;
-            if (disposing)
-            {
-                nng_aio_stop(aioHandle);
-            }
-            
-            nng_aio_free(aioHandle);
-            aioHandle = nng_aio.Null;
-            disposed = true;
-        }
-        bool disposed = false;
         #endregion
     }
 
+    /// <summary>
+    /// High-level wrapper around `nng_ctx`.
+    /// </summary>
     public class AsyncCtx : INngCtx, IDisposable
     {
         public nng_ctx NngCtx { get; protected set; }
@@ -163,6 +237,11 @@ namespace nng
             => nng_ctx_setopt_string(NngCtx, name, data);
         public int SetOpt(string name, UInt64 data)
             => nng_ctx_setopt_uint64(NngCtx, name, data);
+
+        public void Send(INngAio aio) =>
+            nng_ctx_send(NngCtx, aio.NngAio);
+        public void Recv(INngAio aio) =>
+            nng_ctx_recv(NngCtx, aio.NngAio);
 
         #region IDisposable
         public void Dispose()

--- a/nng.NETCore/Factory.cs
+++ b/nng.NETCore/Factory.cs
@@ -43,7 +43,13 @@ namespace nng.Factories
         public NngResult<IRespondentSocket> RespondentOpen() => RespondentSocket.Open();
         public NngResult<ISurveyorSocket> SurveyorOpen() => SurveyorSocket.Open();
 
+        #region INngAsyncFactory
+        public NngResult<INngAio> CreateAio(AioCallback callback) => AsyncIO.Create(callback);
+        public NngResult<INngCtx> CreateCtx(ISocket socket) => AsyncCtx.Create(socket);
+        #endregion
+
         #region IAsyncContextFactory
+
         public NngResult<ISendAsyncContext<IMessage>> CreateSendAsyncContext(ISocket socket)
         {
             return SendAsyncContext<IMessage>.Create(this, socket);
@@ -85,10 +91,25 @@ namespace nng.Factories
         }
         #endregion
 
-        #region IMiscFactory
+        #region INngMiscFactory
         public NngResult<IStatRoot> GetStatSnapshot()
         {
             return Stat.GetStatSnapshot();
+        }
+        #endregion
+
+        #region INngStreamFactory
+        public NngResult<INngStreamListener> StreamListenerCreate(string addr)
+        {
+            return StreamListener.Alloc(addr);
+        }
+        public NngResult<INngStreamDialer> StreamDialerCreate(string addr)
+        {
+            return StreamDialer.Alloc(addr);
+        }
+        public NngResult<INngStream> StreamFrom(INngAio aio)
+        {
+            return Stream.From(aio);
         }
         #endregion
     }

--- a/nng.NETCore/Native/Aio.cs
+++ b/nng.NETCore/Native/Aio.cs
@@ -11,9 +11,6 @@ namespace nng.Native.Aio
 #endif
     public sealed class UnsafeNativeMethods
     {
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void AioCallback(IntPtr arg);
-
         //[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         //public delegate void AioCancelFunction(nng_aio aio, IntPtr ptr, Int32 val);
 
@@ -71,7 +68,12 @@ namespace nng.Native.Aio
         public static extern void nng_aio_set_timeout(nng_aio aio, nng_duration timeout);
 
         [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
-        public static extern int nng_aio_set_iov(nng_aio aio, UInt32 count, nng_iov iov);
+        static extern int nng_aio_set_iov(nng_aio aio, UInt32 niov, nng_iov[] iov);
+
+        public static Int32 nng_aio_set_iov(nng_aio aio, nng_iov[] iov)
+        {
+            return nng_aio_set_iov(aio, (UInt32)iov.Length, iov);
+        }
 
         // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
         // public static extern bool nng_aio_begin(nng_aio aio);

--- a/nng.NETCore/Native/Stream.cs
+++ b/nng.NETCore/Native/Stream.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace nng.Native.Stream
+{
+    using static Globals;
+
+#if NETSTANDARD2_0
+    [System.Security.SuppressUnmanagedCodeSecurity]
+#endif
+    public sealed class UnsafeNativeMethods
+    {
+        #region nng_stream
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_free(nng_stream stream);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_close(nng_stream stream);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_send(nng_stream stream, nng_aio aio);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_recv(nng_stream stream, nng_aio aio);
+
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set(nng_stream stream, string name, byte[] data, UIntPtr size);
+        public static Int32 nng_stream_set(nng_stream stream, string name, byte[] data)
+        {
+            return nng_stream_set(stream, name, data, (UIntPtr)data.Length);
+        }
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_get(nng_stream dialer, string name, void *, size_t *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_bool(nng_stream dialer, string name, out bool data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_int(nng_stream dialer, string name, out Int32 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_ms(nng_stream dialer, string name, out nng_duration data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_size(nng_stream dialer, string name, out UIntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_uint64(nng_stream dialer, string name, out UInt64 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_string(nng_stream dialer, string name, out IntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_get_ptr(nng_stream dialer, string name, out IntPtr data);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_get_addr(nng_stream dialer, string name, nng_sockaddr *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_bool(nng_stream dialer, string name, bool value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_int(nng_stream dialer, string name, Int32 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_ms(nng_stream dialer, string name, nng_duration value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_size(nng_stream dialer, string name, UIntPtr value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_uint64(nng_stream dialer, string name, UInt64 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_string(nng_stream dialer, string name, string value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_set_ptr(nng_stream dialer, string name, IntPtr value);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_set_addr(nng_stream dialer, string name, const nng_sockaddr *);
+
+        #endregion
+
+        #region nng_stream_dialer
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_alloc(ref nng_stream_dialer dialer, string addr);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_dialer_alloc_url(ref nng_stream_dialer dialer, const nng_url *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_dialer_free(nng_stream_dialer dialer);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_dialer_close(nng_stream_dialer dialer);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_dialer_dial(nng_stream_dialer dialer, nng_aio aio);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32  nng_stream_dialer_set(nng_stream_dialer dialer, string name, byte[] data, UIntPtr size);
+        public static Int32 nng_stream_dialer_set(nng_stream_dialer dialer, string name, byte[] data)
+        {
+            return nng_stream_dialer_set(dialer, name, data, (UIntPtr)data.Length);
+        }
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_dialer_get(nng_stream_dialer dialer, string name, void *, size_t *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_bool(nng_stream_dialer dialer, string name, out bool data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_int(nng_stream_dialer dialer, string name, out Int32 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_ms(nng_stream_dialer dialer, string name, out nng_duration data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_size(nng_stream_dialer dialer, string name, out UIntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_uint64(nng_stream_dialer dialer, string name, out UInt64 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_string(nng_stream_dialer dialer, string name, out IntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_get_ptr(nng_stream_dialer dialer, string name, out IntPtr data);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_dialer_get_addr(nng_stream_dialer dialer, string name, nng_sockaddr *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_bool(nng_stream_dialer dialer, string name, bool value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_int(nng_stream_dialer dialer, string name, Int32 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_ms(nng_stream_dialer dialer, string name, nng_duration value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_size(nng_stream_dialer dialer, string name, UIntPtr value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_uint64(nng_stream_dialer dialer, string name, UInt64 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_string(nng_stream_dialer dialer, string name, string value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_dialer_set_ptr(nng_stream_dialer dialer, string name, IntPtr value);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_dialer_set_addr(nng_stream_dialer dialer, string name, const nng_sockaddr *);
+        #endregion
+
+        #region nng_stream_listener
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_alloc(ref nng_stream_listener listener, string url);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_listener_alloc_url(ref nng_stream_listener listener, const nng_url *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_listener_free(nng_stream_listener listener);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_listener_close(nng_stream_listener listener);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32  nng_stream_listener_listen(nng_stream_listener listener);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void nng_stream_listener_accept(nng_stream_listener listener, nng_aio aio);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32  nng_stream_listener_set(nng_stream_listener listener, string name, byte[] data, UIntPtr size);
+        public static Int32 nng_stream_listener_set(nng_stream_listener listener, string name, byte[] data)
+        {
+            return nng_stream_listener_set(listener, name, data, (UIntPtr)data.Length);
+        }
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_listener_get(nng_stream_listener listener, string name, void *, size_t *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_bool(nng_stream_listener listener, string name, out bool data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_int(nng_stream_listener listener, string name, out Int32 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_ms(nng_stream_listener listener, string name, out nng_duration data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_size(nng_stream_listener listener, string name, out UIntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_uint64(nng_stream_listener listener, string name, out UInt64 data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_string(nng_stream_listener listener, string name, out IntPtr data);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_get_ptr(nng_stream_listener listener, string name, out IntPtr data);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_listener_get_addr(nng_stream_listener listener, string name, nng_sockaddr *);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_bool(nng_stream_listener listener, string name, bool value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_int(nng_stream_listener listener, string name, Int32 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_ms(nng_stream_listener listener, string name, nng_duration value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_size(nng_stream_listener listener, string name, UIntPtr value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_uint64(nng_stream_listener listener, string name, UInt64 value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_string(nng_stream_listener listener, string name, string value);
+        [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        public static extern Int32 nng_stream_listener_set_ptr(nng_stream_listener listener, string name, IntPtr value);
+        // [DllImport(NngDll, CallingConvention = CallingConvention.Cdecl)]
+        // public static extern Int32 nng_stream_listener_set_addr(nng_stream_listener listener, string name, const nng_sockaddr * value);
+        #endregion
+    }
+}

--- a/nng.NETCore/Pair.cs
+++ b/nng.NETCore/Pair.cs
@@ -30,7 +30,7 @@ namespace nng
     }
 
     /// <summary>
-    /// Pair version 0 socket for pair protocol
+    /// Pair version 1 socket for pair protocol
     /// </summary>
     public class Pair1Socket : Socket, IPairSocket
     {

--- a/nng.NETCore/PubSub.cs
+++ b/nng.NETCore/PubSub.cs
@@ -49,7 +49,7 @@ namespace nng
         {
             var context = new SubAsyncContext<T> { Factory = factory, Socket = socket };
             var res = context.InitAio();
-            return NngResult<ISubAsyncContext<T>>.OkIfZero(res, context);
+            return res.Into<ISubAsyncContext<T>>(context);
         }
     }
 }

--- a/nng.NETCore/PushPullAsync.cs
+++ b/nng.NETCore/PushPullAsync.cs
@@ -13,7 +13,7 @@ namespace nng
         {
             var context = new SendAsyncContext<T> { Factory = factory, Socket = socket };
             var res = context.InitAio();
-            return NngResult<ISendAsyncContext<T>>.OkIfZero(res, context);
+            return res.Into<ISendAsyncContext<T>>(context);
         }
 
         /// <summary>
@@ -29,24 +29,24 @@ namespace nng
 
                 tcs = Extensions.CreateSendResultSource();
                 State = AsyncState.Send;
-                nng_aio_set_msg(aioHandle, Factory.Take(ref message));
-                nng_send_aio(Socket.NngSocket, aioHandle);
+                Aio.SetMsg(Factory.Take(ref message));
+                nng_send_aio(Socket.NngSocket, Aio.NngAio);
                 return tcs.Task;
             }
         }
 
         protected override void AioCallback(IntPtr argument)
         {
-            var res = 0;
+            var res = Unit.Ok;
             switch (State)
             {
                 case AsyncState.Send:
-                    res = nng_aio_result(aioHandle);
-                    if (res != 0)
+                    res = Aio.GetResult();
+                    if (res.IsErr())
                     {
                         HandleFailedSend();
                         State = AsyncState.Init;
-                        tcs.TrySetNngError(res);
+                        tcs.TrySetNngError(res.Err());
                         return;
                     }
                     State = AsyncState.Init;
@@ -68,7 +68,7 @@ namespace nng
         {
             var context = new ResvAsyncContext<T> { Factory = factory, Socket = socket };
             var res = context.InitAio();
-            return NngResult<IReceiveAsyncContext<T>>.OkIfZero(res, context);
+            return res.Into<IReceiveAsyncContext<T>>(context);
         }
 
         /// <summary>
@@ -84,26 +84,26 @@ namespace nng
 
                 tcs = Extensions.CreateReceiveSource<T>(token);
                 State = AsyncState.Recv;
-                nng_recv_aio(Socket.NngSocket, aioHandle);
+                nng_recv_aio(Socket.NngSocket, Aio.NngAio);
                 return tcs.Task;
             }
         }
 
         protected override void AioCallback(IntPtr argument)
         {
-            var res = 0;
+            var res = Unit.Ok;
             switch (State)
             {
                 case AsyncState.Recv:
-                    res = nng_aio_result(aioHandle);
-                    if (res != 0)
+                    res = Aio.GetResult();
+                    if (res.IsErr())
                     {
                         State = AsyncState.Init;
-                        tcs.TrySetNngError(res);
+                        tcs.TrySetNngError(res.Err());
                         return;
                     }
                     State = AsyncState.Init;
-                    nng_msg msg = nng_aio_get_msg(aioHandle);
+                    nng_msg msg = Aio.GetMsg();
                     var message = Factory.CreateMessage(msg);
                     tcs.TrySetResult(NngResult<T>.Ok(message));
                     break;

--- a/nng.NETCore/Stream.cs
+++ b/nng.NETCore/Stream.cs
@@ -1,0 +1,262 @@
+using nng.Native;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace nng
+{
+    using static nng.Native.Stream.UnsafeNativeMethods;
+
+    public class StreamListener : INngStreamListener
+    {
+        nng_stream_listener listener;
+        public nng_stream_listener NngStreamListener => listener;
+
+        public static NngResult<INngStreamListener> Alloc(string addr)
+        {
+            var listener = nng_stream_listener.Null;
+            var res = nng_stream_listener_alloc(ref listener, addr);
+            return NngResult<INngStreamListener>.OkThen(res, () => new StreamListener() { listener = listener});
+        }
+        private StreamListener(){}
+
+        public NngResult<Unit> Listen() => Unit.OkIfZero(nng_stream_listener_listen(listener));
+        public void Accept(INngAio aio) => nng_stream_listener_accept(listener, aio.NngAio);
+        public void Close() => nng_stream_listener_close(listener);
+
+        #region IOptions
+        public int GetOpt(string name, out bool data)
+            => nng_stream_listener_get_bool(NngStreamListener, name, out data);
+        public int GetOpt(string name, out int data)
+            => nng_stream_listener_get_int(NngStreamListener, name, out data);
+        public int GetOpt(string name, out nng_duration data)
+            => nng_stream_listener_get_ms(NngStreamListener, name, out data);
+        public int GetOpt(string name, out IntPtr data)
+            => nng_stream_listener_get_ptr(NngStreamListener, name, out data);
+        public int GetOpt(string name, out UIntPtr data)
+            => nng_stream_listener_get_size(NngStreamListener, name, out data);
+        public int GetOpt(string name, out string data)
+        {
+            IntPtr ptr;
+            var res = nng_stream_listener_get_string(NngStreamListener, name, out ptr);
+            data = NngString.Create(ptr).ToManaged();
+            return res;
+        }
+        public int GetOpt(string name, out UInt64 data)
+            => nng_stream_listener_get_uint64(NngStreamListener, name, out data);
+
+        public int SetOpt(string name, byte[] data)
+            => nng_stream_listener_set(NngStreamListener, name, data);
+        public int SetOpt(string name, bool data)
+            => nng_stream_listener_set_bool(NngStreamListener, name, data);
+        public int SetOpt(string name, int data)
+            => nng_stream_listener_set_int(NngStreamListener, name, data);
+        public int SetOpt(string name, nng_duration data)
+            => nng_stream_listener_set_ms(NngStreamListener, name, data);
+        public int SetOpt(string name, IntPtr data)
+            => nng_stream_listener_set_ptr(NngStreamListener, name, data);
+        public int SetOpt(string name, UIntPtr data)
+            => nng_stream_listener_set_size(NngStreamListener, name, data);
+        public int SetOpt(string name, string data)
+            => nng_stream_listener_set_string(NngStreamListener, name, data);
+        public int SetOpt(string name, UInt64 data)
+            => nng_stream_listener_set_uint64(NngStreamListener, name, data);
+        #endregion
+
+        ~StreamListener() => Dispose(false);
+
+        #region IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+            }
+            
+            nng_stream_listener_free(listener);
+            listener = nng_stream_listener.Null;
+            disposed = true;
+        }
+        bool disposed = false;
+        #endregion
+    }
+
+    public class StreamDialer : INngStreamDialer
+    {
+        nng_stream_dialer dialer;
+        public nng_stream_dialer NngStreamDialer => dialer;
+
+        public static NngResult<INngStreamDialer> Alloc(string addr)
+        {
+            var dialer = nng_stream_dialer.Null;
+            var res = nng_stream_dialer_alloc(ref dialer, addr);
+            return NngResult<INngStreamDialer>.OkThen(res, () => new StreamDialer() { dialer = dialer });
+        }
+        private StreamDialer(){}
+
+        public void Dial(INngAio aio) => nng_stream_dialer_dial(dialer, aio.NngAio);
+        public void Close() => nng_stream_dialer_close(dialer);
+
+        #region IOptions
+        public int GetOpt(string name, out bool data)
+            => nng_stream_dialer_get_bool(NngStreamDialer, name, out data);
+        public int GetOpt(string name, out int data)
+            => nng_stream_dialer_get_int(NngStreamDialer, name, out data);
+        public int GetOpt(string name, out nng_duration data)
+            => nng_stream_dialer_get_ms(NngStreamDialer, name, out data);
+        public int GetOpt(string name, out IntPtr data)
+            => nng_stream_dialer_get_ptr(NngStreamDialer, name, out data);
+        public int GetOpt(string name, out UIntPtr data)
+            => nng_stream_dialer_get_size(NngStreamDialer, name, out data);
+        public int GetOpt(string name, out string data)
+        {
+            IntPtr ptr;
+            var res = nng_stream_dialer_get_string(NngStreamDialer, name, out ptr);
+            data = NngString.Create(ptr).ToManaged();
+            return res;
+        }
+        public int GetOpt(string name, out UInt64 data)
+            => nng_stream_dialer_get_uint64(NngStreamDialer, name, out data);
+
+        public int SetOpt(string name, byte[] data)
+            => nng_stream_dialer_set(NngStreamDialer, name, data);
+        public int SetOpt(string name, bool data)
+            => nng_stream_dialer_set_bool(NngStreamDialer, name, data);
+        public int SetOpt(string name, int data)
+            => nng_stream_dialer_set_int(NngStreamDialer, name, data);
+        public int SetOpt(string name, nng_duration data)
+            => nng_stream_dialer_set_ms(NngStreamDialer, name, data);
+        public int SetOpt(string name, IntPtr data)
+            => nng_stream_dialer_set_ptr(NngStreamDialer, name, data);
+        public int SetOpt(string name, UIntPtr data)
+            => nng_stream_dialer_set_size(NngStreamDialer, name, data);
+        public int SetOpt(string name, string data)
+            => nng_stream_dialer_set_string(NngStreamDialer, name, data);
+        public int SetOpt(string name, UInt64 data)
+            => nng_stream_dialer_set_uint64(NngStreamDialer, name, data);
+        #endregion
+
+        ~StreamDialer() => Dispose(false);
+
+        #region IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+            }
+            
+            nng_stream_dialer_free(dialer);
+            dialer = nng_stream_dialer.Null;
+            disposed = true;
+        }
+        bool disposed = false;
+        #endregion
+    }
+
+    public class Stream : INngStream
+    {
+        nng_stream stream;
+        public nng_stream NngStream => stream;
+
+        public static NngResult<INngStream> From(INngAio aio)
+        {
+            var ptr = aio.GetOutput(0);
+            if (ptr == IntPtr.Zero)
+            {
+                return NngResult<INngStream>.Fail(-1);
+            }
+            else
+            {
+                var stream = new Stream{stream = new nng_stream(ptr)};
+                return NngResult<INngStream>.Ok(stream);
+            }
+        }
+
+        private Stream(){}
+
+        public void Send(INngAio aio) => nng_stream_send(stream, aio.NngAio);
+
+        public void Recv(INngAio aio) => nng_stream_recv(stream, aio.NngAio);
+
+        public void Close() => nng_stream_close(stream);
+
+        #region IOptions
+        public int GetOpt(string name, out bool data)
+            => nng_stream_get_bool(NngStream, name, out data);
+        public int GetOpt(string name, out int data)
+            => nng_stream_get_int(NngStream, name, out data);
+        public int GetOpt(string name, out nng_duration data)
+            => nng_stream_get_ms(NngStream, name, out data);
+        public int GetOpt(string name, out IntPtr data)
+            => nng_stream_get_ptr(NngStream, name, out data);
+        public int GetOpt(string name, out UIntPtr data)
+            => nng_stream_get_size(NngStream, name, out data);
+        public int GetOpt(string name, out string data)
+        {
+            IntPtr ptr;
+            var res = nng_stream_get_string(NngStream, name, out ptr);
+            data = NngString.Create(ptr).ToManaged();
+            return res;
+        }
+        public int GetOpt(string name, out UInt64 data)
+            => nng_stream_get_uint64(NngStream, name, out data);
+
+        public int SetOpt(string name, byte[] data)
+            => nng_stream_set(NngStream, name, data);
+        public int SetOpt(string name, bool data)
+            => nng_stream_set_bool(NngStream, name, data);
+        public int SetOpt(string name, int data)
+            => nng_stream_set_int(NngStream, name, data);
+        public int SetOpt(string name, nng_duration data)
+            => nng_stream_set_ms(NngStream, name, data);
+        public int SetOpt(string name, IntPtr data)
+            => nng_stream_set_ptr(NngStream, name, data);
+        public int SetOpt(string name, UIntPtr data)
+            => nng_stream_set_size(NngStream, name, data);
+        public int SetOpt(string name, string data)
+            => nng_stream_set_string(NngStream, name, data);
+        public int SetOpt(string name, UInt64 data)
+            => nng_stream_set_uint64(NngStream, name, data);
+        #endregion
+
+        ~Stream() => Dispose(false);
+
+        #region IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposed)
+                return;
+            if (disposing)
+            {
+            }
+            
+            nng_stream_free(stream);
+            stream = nng_stream.Null;
+            disposed = true;
+        }
+        bool disposed = false;
+        #endregion
+    }
+}

--- a/nng.Shared/Core.cs
+++ b/nng.Shared/Core.cs
@@ -106,7 +106,7 @@ namespace nng
         int Id { get; }
     }
 
-    public static class Extensions
+    public static partial class Extensions
     {
         public static TaskCompletionSource<NngResult<T>> CreateSource<T>()
         {
@@ -140,20 +140,12 @@ namespace nng
         {
             socket.TrySetResult(NngResult<T>.Ok(message));
         }
-        public static void TrySetNngError<T>(this TaskCompletionSource<NngResult<T>> socket, int error)
+        public static void TrySetNngError<T>(this TaskCompletionSource<NngResult<T>> socket, NngErrno error)
         {
-            if (error == 0)
-            {
-                return;
-            }
             socket.TrySetResult(NngResult<T>.Fail(error));
         }
-        public static void TrySetNngError<T>(this CancellationTokenTaskSource<NngResult<T>> socket, int error)
+        public static void TrySetNngError<T>(this CancellationTokenTaskSource<NngResult<T>> socket, NngErrno error)
         {
-            if (error == 0)
-            {
-                return;
-            }
             socket.TrySetResult(NngResult<T>.Fail(error));
         }
     }

--- a/nng.Shared/Defines.cs
+++ b/nng.Shared/Defines.cs
@@ -6,6 +6,11 @@ namespace nng.Native
 {
     public sealed partial class Defines
     {
+        /// <summary>
+        /// Maximum number of scatter/gather iov supported (see <a href=https://nng.nanomsg.org/man/v1.3.2/nng_aio_set_iov.3.html>nng_aio_set_iov</a>)
+        /// </summary>
+        public const int MAX_IOV_BUFFERS = 8;
+
         public const int NNG_MAXADDRLEN = 128;
 
         public const int NNG_DURATION_INFINITE = -1;
@@ -241,8 +246,8 @@ namespace nng.Native
     [StructLayout(LayoutKind.Sequential)]
     public struct nng_iov
     {
-#pragma warning disable CS0169
-        IntPtr ptr;
+        public IntPtr iov_buf;
+        public UIntPtr iov_len;
     }
 
     public enum nng_stat_type_enum
@@ -380,6 +385,33 @@ namespace nng.Native
     [StructLayout(LayoutKind.Sequential, Size = 16)]
     struct uint8_16_blob
     {
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_stream
+    {
+        IntPtr opaque_ptr;
+        public static readonly nng_stream Null = new nng_stream { opaque_ptr = IntPtr.Zero };
+
+        [System.ComponentModel.EditorBrowsable(System.ComponentModel.EditorBrowsableState.Advanced)]
+        public nng_stream(IntPtr ptr)
+        {
+            opaque_ptr = ptr;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_stream_dialer
+    {
+        IntPtr opaque_ptr;
+        public static readonly nng_stream_dialer Null = new nng_stream_dialer { opaque_ptr = IntPtr.Zero };
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct nng_stream_listener
+    {
+        IntPtr opaque_ptr;
+        public static readonly nng_stream_listener Null = new nng_stream_listener { opaque_ptr = IntPtr.Zero };
     }
 
 #endregion

--- a/nng.Shared/IAio.cs
+++ b/nng.Shared/IAio.cs
@@ -1,0 +1,28 @@
+using nng.Native;
+using System;
+using System.Runtime.InteropServices;
+
+namespace nng
+{
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    public delegate void AioCallback(IntPtr arg);
+
+    public interface IHasAio
+    {
+        INngAio Aio { get; }
+    }
+
+    public interface INngAio : IDisposable
+    {
+        nng_aio NngAio { get; }
+        void SetMsg(nng_msg msg);
+        NngResult<Unit> SetIov(Span<nng_iov> buffers);
+        void SetTimeout(int msTimeout);
+        UIntPtr Count();
+        NngResult<Unit> GetResult();
+        nng_msg GetMsg();
+        IntPtr GetOutput(UInt32 index);
+        void Wait();
+        void Cancel();
+    }
+}

--- a/nng.Shared/IAsyncContext.cs
+++ b/nng.Shared/IAsyncContext.cs
@@ -24,9 +24,11 @@ namespace nng
     /// <summary>
     /// Context for asynchronous nng operations.  Most likely involves nng_aio, only involves nng_ctx if supported by protocol.
     /// </summary>
-    public interface IAsyncContext : IHasSocket, IDisposable
+    public interface IAsyncContext : IHasSocket, IHasAio, IDisposable
     {
+        [Obsolete("Use SetTimeout() on IHasAio.Aio property")]
         void SetTimeout(int msTimeout);
+        [Obsolete("Use Cancel() on IHasAio.Aio property")]
         void Cancel();
     }
 

--- a/nng.Shared/ICtx.cs
+++ b/nng.Shared/ICtx.cs
@@ -22,5 +22,7 @@ namespace nng
     public interface INngCtx : IOptions
     {
         nng_ctx NngCtx { get; }
+        void Send(INngAio aio);
+        void Recv(INngAio aio);
     }
 }

--- a/nng.Shared/IFactory.cs
+++ b/nng.Shared/IFactory.cs
@@ -35,6 +35,12 @@ namespace nng
         NngResult<ISurveyorSocket> SurveyorOpen();
     }
 
+    public interface INngAsyncFactory
+    {
+        NngResult<INngAio> CreateAio(AioCallback callback = default);
+        NngResult<INngCtx> CreateCtx(ISocket socket);
+    }
+
     public enum SendReceiveContextSubtype
     {
         Bus,
@@ -55,12 +61,22 @@ namespace nng
         NngResult<ISurveyorAsyncContext<T>> CreateSurveyorAsyncContext(ISocket socket);
     }
 
-    public interface IMiscFactory
+    public interface INngMiscFactory
     {
         NngResult<IStatRoot> GetStatSnapshot();
     }
 
-    public interface IAPIFactory<T> : IMessageFactory<T>, ISocketFactory, IAsyncContextFactory<T>, IMiscFactory
+    public interface INngStreamFactory
+    {
+        NngResult<INngStreamListener> StreamListenerCreate(string addr);
+        NngResult<INngStreamDialer> StreamDialerCreate(string addr);
+        NngResult<INngStream> StreamFrom(INngAio aio);
+    }
+
+    public interface INngApiFactory : ISocketFactory, INngAsyncFactory, INngStreamFactory, INngMiscFactory
+    {}
+
+    public interface IAPIFactory<T> : INngApiFactory, IMessageFactory<T>,  IAsyncContextFactory<T>
     { }
 
 }

--- a/nng.Shared/IStream.cs
+++ b/nng.Shared/IStream.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace nng
+{
+    public interface INngStreamDialer : IOptions, IDisposable
+    {
+        void Dial(INngAio aio);
+        void Close();
+    }
+
+    public interface INngStreamListener : IOptions, IDisposable
+    {
+        NngResult<Unit> Listen();
+        void Accept(INngAio aio);
+        void Close();
+    }
+
+    public interface INngStream : IOptions, IDisposable
+    {
+        void Send(INngAio aio);
+        void Recv(INngAio aio);
+        void Close();
+    }
+}

--- a/nng.Shared/Result.cs
+++ b/nng.Shared/Result.cs
@@ -152,6 +152,16 @@ namespace nng
             return Err((NngErrno)errno);
         }
 
+        /// <summary>
+        /// Create fail result using errno.
+        /// </summary>
+        /// <param name="errno"></param>
+        /// <returns></returns>
+        public static NngResult<TOk> Fail(NngErrno errno)
+        {
+            return Err(errno);
+        }
+
         public bool IsOk() => result.IsOk();
         public bool IsErr() => !IsOk();
         public bool IsErr(NngErrno err) => IsErr() && Err() == err;
@@ -198,6 +208,18 @@ namespace nng
             if (IsOk())
             {
                 return NngResult<T>.Ok(func());
+            }
+            else
+            {
+                return IntoErr<T>();
+            }
+        }
+
+        public NngResult<T> Into<T>(T value)
+        {
+            if (IsOk())
+            {
+                return NngResult<T>.Ok(value);
             }
             else
             {

--- a/tests/Complex.cs
+++ b/tests/Complex.cs
@@ -1,0 +1,86 @@
+using nng.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace nng.Tests
+{
+    using static nng.Tests.Util;
+    using static nng.Native.Defines;
+
+    [Collection("nng")]
+    public class ComplexTests
+    {
+        IAPIFactory<IMessage> factory;
+
+        public ComplexTests(NngCollectionFixture collectionFixture)
+        {
+            factory = collectionFixture.Factory;
+        }
+
+        IMessage MsgRandom()
+        {
+            var msg = factory.CreateMessage();
+            msg.Append(Guid.NewGuid().ToByteArray());
+            return msg;
+        }
+
+        [Fact]
+        public async Task Issue89_FullDuplexPairWithContexts()
+        {
+            const int MAX_CLIENT_COUNT = 4;
+            string url = Util.UrlInproc();
+            var tasks = new List<Task>();
+            var cts = new CancellationTokenSource();
+            int numReceived = 0;
+
+            using (var socket = factory.PairOpen().ThenListenAs(out var listener, url).Unwrap())
+            {
+                listener.Start();
+
+                foreach (var _ in Enumerable.Range(0, MAX_CLIENT_COUNT))
+                {
+                    var task = Task.Run(async () => {
+                        using (var context = socket.CreateAsyncContext(factory).Unwrap())
+                        {
+                            context.Aio.SetTimeout(100);
+                            while (!cts.IsCancellationRequested)
+                            {
+                                var _s = await context.Send(factory.CreateMessage());
+                                var _r = (await context.Receive(cts.Token));
+                            }
+                        }
+                    });
+                    tasks.Add(task);
+                }
+
+                foreach (var _ in Enumerable.Range(0, MAX_CLIENT_COUNT))
+                {
+                    var task = Task.Run(async () => {
+                        using (var socket = factory.PairOpen().ThenDial(url).Unwrap())
+                        using (var context = socket.CreateAsyncContext(factory).Unwrap())
+                        {
+                            context.Aio.SetTimeout(100);
+                            while (!cts.IsCancellationRequested)
+                            {
+                                var _s = await context.Send(factory.CreateMessage());
+                                var recv = (await context.Receive(cts.Token));
+                                if (recv.IsOk())
+                                    Interlocked.Increment(ref numReceived);
+                            }
+                        }
+                    });
+                    tasks.Add(task);
+                }
+
+                await Util.CancelAfterAssertwait(tasks, cts);
+            }
+            
+            // TODO: better check that all clients/listeners both send and receive messages
+            Assert.True(numReceived > MAX_CLIENT_COUNT*2);
+        }
+    }
+}

--- a/tests/CtxTests.cs
+++ b/tests/CtxTests.cs
@@ -47,15 +47,19 @@ namespace nng.Tests
             var url = UrlIpc();
 
             // Setting receive timeout on nng_ctx works
-            using (var socket = Factory.ReplierOpen().ThenListen(url).Unwrap())
-            using (var rep = socket.CreateAsyncContext(Factory).Unwrap())
-            {
-                Assert.Equal(0, rep.Ctx.SetOpt(NNG_OPT_RECVTIMEO, nng_duration.Zero));
-                Assert.True((await rep.Receive()).Err() == NngErrno.ECLOSED);
-            }
+            var task = Task.Run(async () => {
+                using (var socket = Factory.ReplierOpen().ThenListen(url).Unwrap())
+                using (var rep = socket.CreateAsyncContext(Factory).Unwrap())
+                {
+                    Assert.Equal(0, rep.Ctx.SetOpt(NNG_OPT_RECVTIMEO, nng_duration.Zero));
+                    Assert.True((await rep.Receive()).Err() == NngErrno.ECLOSED);
+                }
+            });
+            var first = await Task.WhenAny(Task.WhenAll(task), Task.Delay(Util.ShortTestMs));
+            Assert.Equal(task, first);
 
             // Setting receive timeout on socket doesn't timeout read from nng_ctx
-            var task = Task.Run(async () => {
+            task = Task.Run(async () => {
                 using (var socket = Factory.ReplierOpen().ThenListen(url).Unwrap())
                 using (var rep = socket.CreateAsyncContext(Factory).Unwrap())
                 {
@@ -64,7 +68,7 @@ namespace nng.Tests
                 }
             });
             var timeout = Task.Delay(Util.ShortTestMs);
-            var first = await Task.WhenAny(Task.WhenAll(task), timeout);
+            first = await Task.WhenAny(Task.WhenAll(task), timeout);
             Assert.Equal(timeout, first);
         }
     }

--- a/tests/Fixtures.cs
+++ b/tests/Fixtures.cs
@@ -23,22 +23,14 @@ namespace nng.Tests
 
         public IAPIFactory<IMessage> Factory { get; private set; }
 
-        int Iterations { get; } = 10;
-
         public void TestIterate(Action testFunction)
         {
-            for (int i = 0; i < Iterations; ++i)
-            {
-                testFunction();
-            }
+            Util.RepeatTest(testFunction);
         }
 
         public async Task TestIterate(Func<Task> testFunction)
         {
-            for (int i = 0; i < Iterations; ++i)
-            {
-                await testFunction();
-            }
+            await Util.RepeatTest(testFunction);
         }
     }
 

--- a/tests/StreamTests.cs
+++ b/tests/StreamTests.cs
@@ -1,0 +1,126 @@
+using nng.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace nng.Tests
+{
+    using static nng.Tests.Util;
+    using static nng.Native.Defines;
+
+    [Collection("nng")]
+    public class StreamTests
+    {
+        IAPIFactory<IMessage> factory;
+
+        public StreamTests(NngCollectionFixture collectionFixture)
+        {
+            factory = collectionFixture.Factory;
+        }
+
+        [Fact]
+        public void Basic()
+        {
+            using (var stream = new StreamStuff(factory))
+            {
+                
+            }
+        }
+
+        [Fact]
+        public void SendRecv()
+        {
+            using (var s = new StreamStuff(factory))
+            {
+                // Unmanaged memory
+                var lbytes = Util.RandomBytes();
+                var lmem = factory.CreateAlloc(lbytes.Length);
+                lbytes.CopyTo(lmem.AsSpan());
+                var liov = new nng_iov {iov_buf = lmem.Ptr, iov_len = lmem.Length};
+                var dmem = factory.CreateAlloc(lbytes.Length);
+                var diov = new nng_iov {iov_buf = dmem.Ptr, iov_len = dmem.Length};
+                
+                s.laio.SetIov(new []{liov});
+                s.daio.SetIov(new []{diov});
+                s.lstream.Send(s.daio);
+                s.dstream.Recv(s.laio);
+                s.laio.Wait();
+                s.daio.Wait();
+                Assert.NotEqual(UIntPtr.Zero, s.daio.Count());
+                Assert.True(Util.BytesEqual(lmem.AsSpan(), dmem.AsSpan()));
+
+                // Pinned managed memory
+                unsafe 
+                {
+                    lbytes = Util.RandomBytes();
+                    var dbytes = new byte[lbytes.Length];
+                    fixed(byte* lptr = lbytes)
+                    fixed(byte* dptr = dbytes)
+                    {
+                        liov = new nng_iov {iov_buf = (IntPtr)lptr, iov_len = (UIntPtr)lbytes.Length };
+                        diov = new nng_iov {iov_buf = (IntPtr)dptr, iov_len = (UIntPtr)dbytes.Length };
+
+                        s.laio.SetIov(new []{liov});
+                        s.daio.SetIov(new []{diov});
+                        s.lstream.Send(s.daio);
+                        s.dstream.Recv(s.laio);
+                        s.laio.Wait();
+                        s.daio.Wait();
+                        Assert.NotEqual(UIntPtr.Zero, s.daio.Count());
+                        Assert.True(Util.BytesEqual(lbytes, dbytes));
+                    }
+                }
+            }
+        }
+    }
+
+    class StreamStuff : IDisposable
+    {
+        public readonly INngAio laio;
+        public readonly INngAio daio;
+        public readonly INngStreamListener listener;
+        public readonly INngStreamDialer dialer;
+        public readonly INngStream lstream;
+        public readonly INngStream dstream;
+
+        public StreamStuff(IAPIFactory<IMessage> factory)
+        {
+            var url = UrlIpc();
+            laio = factory.CreateAio().Unwrap();
+            daio = factory.CreateAio().Unwrap();
+            listener = factory.StreamListenerCreate(url).Unwrap();
+            dialer = factory.StreamDialerCreate(url).Unwrap();
+
+            laio.SetTimeout(Util.DelayShortMs);
+            daio.SetTimeout(Util.DelayShortMs);
+
+            listener.Listen().Unwrap();
+            listener.Accept(laio);
+            dialer.Dial(daio);
+            laio.Wait();
+            daio.Wait();
+
+            // Connected nng_stream is stored as aio output 0 and shouldn't be NULL
+            Assert.NotEqual(IntPtr.Zero, laio.GetOutput(0));
+            Assert.NotEqual(IntPtr.Zero, daio.GetOutput(0));
+
+            lstream = factory.StreamFrom(laio).Unwrap();
+            dstream = factory.StreamFrom(daio).Unwrap();
+        }
+
+        #region IDisposable
+        public void Dispose()
+        {
+            laio?.Dispose();
+            daio?.Dispose();
+            listener?.Dispose();
+            dialer?.Dispose();
+            lstream?.Dispose();
+            dstream?.Dispose();
+        }
+        #endregion
+    }
+}

--- a/tests/Util.cs
+++ b/tests/Util.cs
@@ -1,5 +1,6 @@
 using nng.Native;
 using System;
+using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
 using System.Threading;
@@ -15,15 +16,19 @@ namespace nng.Tests
         public const int ShortTestMs = 250;
         public const int DefaultTimeoutMs = 5000;
 
+        public const int DelayShortMs = 25;
+
         public static string UrlIpc() => "ipc://" + Guid.NewGuid().ToString();
         public static string UrlInproc() => "inproc://" + Guid.NewGuid().ToString();
         public static string UrlTcp() => "tcp://localhost:0";
         public static string UrlWs() => "ws://localhost:0";
 
-        public static byte[] TopicRandom() => Guid.NewGuid().ToByteArray();
+        public static byte[] RandomBytes() => Guid.NewGuid().ToByteArray();
+        public static byte[] TopicRandom() => RandomBytes();
+
 
         public static Task WaitReady() => Task.Delay(100);
-        public static Task WaitShort() => Task.Delay(25);
+        public static Task WaitShort() => Task.Delay(DelayShortMs);
 
         public static string GetDialUrl(IListener listener, string url)
         {
@@ -179,6 +184,24 @@ namespace nng.Tests
         {
             socket.SetOpt(nng.Native.Defines.NNG_OPT_RECVTIMEO, new nng_duration{TimeMs = timeoutMs});
             socket.SetOpt(nng.Native.Defines.NNG_OPT_SENDTIMEO, new nng_duration{TimeMs = timeoutMs});
+        }
+
+        const int ITERATIONS = 10;
+
+        public static void RepeatTest(Action testFunction)
+        {
+            foreach (var _  in Enumerable.Range(0, ITERATIONS))
+            {
+                testFunction();
+            }
+        }
+
+        public static async Task RepeatTest(Func<Task> testFunction)
+        {
+            foreach (var _  in Enumerable.Range(0, ITERATIONS))
+            {
+                await testFunction();
+            }
         }
 
         public static readonly Random rng = new Random();


### PR DESCRIPTION
- Initial wrapping of nng_stream* functions and aio iov for vectored IO
- Move aio functionality from AsyncBase/IAsyncContext to AsyncIO/INngAio
- Factory support to create StreamListener/Dialer and raw Aio/Ctx wrappers
- Deprecate UnsafeNativeMethods.AioCallback (moved to nng.Shared.dll::nng.AioCallback)
- IAsyncContext.SetTimeout and Cancel market obsolete (use Functions on IHasAio.Aio property)
- fix #89 Example duplex pair with contexts