### PR TITLE
Fixup management of managed and unmanaged resources

### DIFF
--- a/nng.NET/AsyncContext.cs
+++ b/nng.NET/AsyncContext.cs
@@ -253,12 +253,19 @@ namespace nng
         {
             if (disposed)
                 return;
+
             if (disposing)
             {
-                var _ = nng_ctx_close(NativeNngStruct);
+                // No managed resources to dispose
             }
+
+            var _ = nng_ctx_close(NativeNngStruct);
+
             disposed = true;
         }
+
+        ~NngCtx() => Dispose(false);
+
         bool disposed = false;
         #endregion
     }

--- a/nng.NET/AsyncContext.cs
+++ b/nng.NET/AsyncContext.cs
@@ -174,10 +174,24 @@ namespace nng
         protected object sync = new object();
 
         #region IDisposable
-        public void Dispose()
+        public void Dispose() => Dispose(true);
+
+        protected virtual void Dispose(bool disposing)
         {
-            Aio?.Dispose();
+            if (disposed)
+                return;
+
+            if (disposing)
+            {
+                Aio?.Dispose();
+            }
+
+            // No unmanaged resources to cleanup
+
+            disposed = true;
         }
+
+        bool disposed = false;
         #endregion
     }
 

--- a/nng.NET/Dialer.cs
+++ b/nng.NET/Dialer.cs
@@ -82,12 +82,19 @@ namespace nng
         {
             if (disposed)
                 return;
+
             if (disposing)
             {
-                int _ = nng_dialer_close(NativeNngStruct);
+                // No managed resources to dispose
             }
+
+            int _ = nng_dialer_close(NativeNngStruct);
+
             disposed = true;
         }
+
+        ~NngDialer() => Dispose(false);
+
         bool disposed = false;
         #endregion
 

--- a/nng.NET/Listener.cs
+++ b/nng.NET/Listener.cs
@@ -84,12 +84,19 @@ namespace nng
         {
             if (disposed)
                 return;
+
             if (disposing)
             {
-                int _ = nng_listener_close(NativeNngStruct);
+                // No managed resources to dispose
             }
+
+            int _ = nng_listener_close(NativeNngStruct);
+
             disposed = true;
         }
+
+        ~NngListener() => Dispose(false);
+
         bool disposed = false;
         #endregion
 

--- a/nng.NET/Memory.cs
+++ b/nng.NET/Memory.cs
@@ -40,7 +40,7 @@ namespace nng
             Ptr = default;
             Length = default;
         }
-        
+
         #region IDisposable
         public void Dispose()
         {
@@ -52,13 +52,20 @@ namespace nng
         {
             if (disposed)
                 return;
+
             if (disposing)
             {
-                if (Ptr != IntPtr.Zero)
-                    nng_free(Ptr, Length);
+                // No managed resources to dispose
             }
+
+            if (Ptr != IntPtr.Zero)
+                nng_free(Ptr, Length);
+
             disposed = true;
         }
+
+        ~NngAlloc() => Dispose(false);
+
         bool disposed = false;
         #endregion
     }

--- a/nng.NET/Socket.cs
+++ b/nng.NET/Socket.cs
@@ -175,12 +175,19 @@ namespace nng
         {
             if (disposed)
                 return;
+
             if (disposing)
             {
-                int _ = nng_close(NativeNngStruct);
+                // No managed resources to dispose
             }
+
+            int _ = nng_close(NativeNngStruct);
+
             disposed = true;
         }
+
+        ~NngSocket() => Dispose(false);
+
         bool disposed = false;
         #endregion
     }

--- a/nng.NET/Stats.cs
+++ b/nng.NET/Stats.cs
@@ -35,10 +35,7 @@ namespace nng
             var res = nng_stats_get(out nng_stat statsp);
             return NngResult<IStatRoot>.OkThen(res, () => new StatRoot { NativeNngStruct = statsp });
         }
-    }
 
-    public class StatRoot : NngStat, IStatRoot
-    {
         #region IDisposable
         public void Dispose()
         {
@@ -52,12 +49,21 @@ namespace nng
                 return;
             if (disposing)
             {
-                nng_stats_free(NativeNngStruct);
+                // No managed resources to dispose
             }
+            nng_stats_free(NativeNngStruct);
             disposed = true;
         }
+
+        ~NngStat() => Dispose(false);
+
         bool disposed = false;
         #endregion
+    }
+
+    public class StatRoot : NngStat, IStatRoot
+    {
+
     }
 
     public class StatChild : NngStat, IStatChild

--- a/nng.NET/String.cs
+++ b/nng.NET/String.cs
@@ -40,11 +40,13 @@ namespace nng
                 return;
             if (disposing)
             {
-                if (Ptr != IntPtr.Zero)
-                    nng_strfree(Ptr);
+                // No managed resources to dispose
             }
+            if (Ptr != IntPtr.Zero)
+                nng_strfree(Ptr);
             disposed = true;
         }
+        ~NngString() => Dispose(false);
         bool disposed = false;
         #endregion
     }


### PR DESCRIPTION
### WIP 
# 🚧  👷  🏗️  
 ...  this is a work in progress but I want to create draft to provide an opportunity for discussion.

### Background
This work stems primarily from reading the [.NET documentation about implementing the "dispose pattern"](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose). 

According to [this section documentation](https://docs.microsoft.com/en-us/dotnet/standard/garbage-collection/implementing-dispose#the-disposebool-method-overload), the implementation of a `void Dispose(bool disposing)` method should:
- Free unmanaged resources (a.k.a. unmanaged memory, file handles, etc.)
- A conditional block that frees managed resources. (i.e. other `IDisposable` objects) that executes only if invoked from `void Dispose()`

The documentation also states that "If the method call comes from a finalizer, only the code that frees unmanaged resources should execute."

### PR Summary
This PR is an attempt to fix some of the classes that must follow the "dispose pattern". The classes affected by this PR:
- `AsyncBase<T>`
- `NngAlloc`
- `NngCtx`
- `NngDialer`
- `NngListener`
- `NngSocket`
- `NngStat`
- `NngString`

### Other Thoughts
In the process of working on this it appears that there are cases for an `IDisposable` to be "owned" by more than one entity which makes clean up difficult - which "owner" should be responsible for invoking `Dispose()` on the object? 🤷 

Example:
1. a user creates a `nng.RepSocket`
2. the user creates a `AsyncBase<T>` class by passing the `nng.RepSocket` to `CreateRepReqAsyncContext()`
3. Now both the user and the `ASyncBase<T>` "own" the `nng.RepSocket`
Since `nng.RepSocket` is an `IDisposable` object, _someone_ must invoke its `Dispose()` method... but who?

This type of problem appears to be a known limitation with `IDisposable`. A brief searching of the web shows some have implemented reference counting wrappers around `IDisposable` objects as a solution (similar to C++ shared_ptr<T>): https://stackoverflow.com/a/22092381

Addressing this probably wont be a small task and seems to fall outside the scope of this PR (at least for now).