### PR TITLE
polymorphism with interface doesnt work

### DIFF
--- a/nng.NET/Factory.cs
+++ b/nng.NET/Factory.cs
@@ -116,17 +116,25 @@ namespace nng.Factories
 
     namespace Compat
     {
-        public class Factory : FactoryBase
+        public class Factory : FactoryBase, ISocketFactory
         {
-            public new NngResult<IPairSocket> PairOpen() => Pair0Socket.Open();   
+            public new NngResult<IPairSocket> PairOpen() => Pair0Socket.Open();
+            NngResult<IPairSocket> ISocketFactory.PairOpen()
+            {
+                return this.PairOpen();
+            }
         }
     }
-    
+
     namespace Latest
     {
-        public class Factory : FactoryBase
+        public class Factory : FactoryBase, ISocketFactory
         {
-            public new NngResult<IPairSocket> PairOpen() => Pair1Socket.Open();   
+            public new NngResult<IPairSocket> PairOpen() => Pair1Socket.Open();
+            NngResult<IPairSocket> ISocketFactory.PairOpen()
+            {
+                return this.PairOpen();
+            }
         }
     }
 }


### PR DESCRIPTION
If we are using derived class that implements an interface throught base type or that interface, then polymorphism doesnt work. It works only in case using derived type explicitly. "public new" it is not enough. The way to go is to explicitly implement the part of the interface that you want to override. https://stackoverflow.com/questions/12314990/override-method-implementation-declared-in-an-interface